### PR TITLE
[codex] Add Capacitor SPM product alias

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -32,9 +32,47 @@ if [ "${#packed_packages[@]}" -ne 1 ]; then
 fi
 
 plugin_name="$(bun -e 'console.log(require("./package.json").name)')"
-cp -R example-app/. "$test_app/"
+if [ -d example-app ]; then
+  cp -R example-app/. "$test_app/"
+else
+  cat > "$test_app/package.json" <<'JSON'
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "mkdir -p dist && cp index.html dist/index.html"
+  },
+  "dependencies": {
+    "@capacitor/android": "^8.0.0",
+    "@capacitor/cli": "^8.0.0",
+    "@capacitor/core": "^8.0.0",
+    "@capacitor/ios": "^8.0.0"
+  },
+  "devDependencies": {}
+}
+JSON
+  cat > "$test_app/capacitor.config.json" <<'JSON'
+{
+  "appId": "com.capgo.pluginexample",
+  "appName": "Plugin Example",
+  "webDir": "dist"
+}
+JSON
+  cat > "$test_app/index.html" <<'HTML'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Plugin Example</title>
+  </head>
+  <body></body>
+</html>
+HTML
+fi
 cd "$test_app"
-bun remove "$plugin_name"
+bun install
+bun remove "$plugin_name" || true
 bun add "${packed_packages[0]}"
 bun run build
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
       "state" : {
-        "revision" : "3fdb4ac03e3c20e86dd9b6feb15d0b129a6ee987",
-        "version" : "7.4.2"
+        "revision" : "992959f0467c781eb6a1637e69d87481238c3672",
+        "version" : "8.3.4"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,9 @@ let package = Package(
     products: [
         .library(
             name: "CapgoCapacitorPluginAudioSession",
+            targets: ["AudioSessionPlugin"]),
+        .library(
+            name: "CapgoCapacitorAudioSession",
             targets: ["AudioSessionPlugin"])
     ],
     dependencies: [

--- a/scripts/check-capacitor-plugin-wiring.mjs
+++ b/scripts/check-capacitor-plugin-wiring.mjs
@@ -199,6 +199,21 @@ function parseSpmNames(packageSwiftPath) {
   return { pkgName: pkg, libNames: uniq(libs) };
 }
 
+function toPascalCasePart(part) {
+  if (!part) return "";
+  return part[0].toUpperCase() + part.slice(1);
+}
+
+function packageNameToSpmProductName(packageName) {
+  if (typeof packageName !== "string") return "";
+  return packageName
+    .replace(/^@/, "")
+    .split(/[\/\W_]+/)
+    .filter(Boolean)
+    .map(toPascalCasePart)
+    .join("");
+}
+
 // ---------------- Validate ----------------
 const errors = [];
 
@@ -240,6 +255,16 @@ if (supportsIos) {
     }
     if (pkgName && libNames.length && !libNames.includes(pkgName)) {
       errors.push(`SPM: Package(name)=${pkgName} not present in .library(name) list ${JSON.stringify(libNames)}`);
+    }
+    if (typeof pkg.name !== "string" || !pkg.name.trim()) {
+      errors.push("package.json: missing valid string name");
+    } else {
+      const expectedProductName = packageNameToSpmProductName(pkg.name);
+      if (expectedProductName && libNames.length && !libNames.includes(expectedProductName)) {
+        errors.push(
+          `SPM: expected Capacitor product ${expectedProductName} from package.json name ${pkg.name}, but .library(name) list is ${JSON.stringify(libNames)}`
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## What
- Add the `CapgoCapacitorAudioSession` SwiftPM library product alias while keeping the existing `CapgoCapacitorPluginAudioSession` product.
- Add a wiring check that requires the Capacitor-generated SPM product name derived from the npm package name.
- Make packed-package CI verification create a minimal temporary Capacitor app when the repo has no `example-app/` fixture.
- Refresh `Package.resolved` to the Capacitor 8 SwiftPM package selected by the existing `from: "8.0.0"` requirement.

## Why
- Capacitor v8 generated app wrapper packages request `CapgoCapacitorAudioSession` for `@capgo/capacitor-audio-session`.
- The plugin only exported `CapgoCapacitorPluginAudioSession`, so host apps could fail during Xcode package resolution.
- CI already expected packed-package verification, but this repo did not contain the fixture it tried to copy.

## How
- Added a second `.library` product that points to the existing `AudioSessionPlugin` target.
- Derived the expected generated product name from `package.json` in the wiring script and fail when it is missing.
- Added a fallback temporary app in `.github/scripts/verify-packed-example.sh`.

## Testing
- `bun run check:wiring`
- `swift package describe --type json`
- `bun run fmt`
- `bun run lint`
- `bun run verify:web`
- `bun run verify:ios`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=$HOME/Library/Android/sdk ANDROID_SDK_ROOT=$HOME/Library/Android/sdk PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH bun run verify:android`
- `bash ./.github/scripts/verify-packed-example.sh web`
- `bash ./.github/scripts/verify-packed-example.sh ios`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=$HOME/Library/Android/sdk ANDROID_SDK_ROOT=$HOME/Library/Android/sdk PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH bash ./.github/scripts/verify-packed-example.sh android`

## Not Tested
- Full Capgo app build with this package restored from a published version, because this PR must ship first before Capgo can consume the fixed package.
